### PR TITLE
refactor: add monorepo structure with React and Vue packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,13 @@ selenium-debug.log
 .DS_Store?
 
 /dist
+**/dist
 /node_modules
+pnpm-lock.yaml
+
+# Generated icon source files
+packages/*/src/icons/
+packages/*/src/index.ts
 
 # Compiled class file
 *.class

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mingcute-icons",
+  "private": true,
+  "scripts": {
+    "generate": "node scripts/generate.mjs",
+    "build": "pnpm -r build",
+    "build:react": "pnpm --filter @mingcute/react build",
+    "build:vue": "pnpm --filter @mingcute/vue build",
+    "clean": "pnpm -r clean"
+  },
+  "devDependencies": {
+    "glob": "^11.0.0",
+    "svgo": "^3.3.2"
+  }
+}

--- a/packages/mingcute-react/package.json
+++ b/packages/mingcute-react/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@mingcute/react",
+  "version": "0.1.0",
+  "description": "MingCute Icons for React",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "types": "./dist/esm/icons/*.d.ts",
+        "default": "./dist/esm/icons/*.js"
+      },
+      "require": {
+        "types": "./dist/cjs/icons/*.d.ts",
+        "default": "./dist/cjs/icons/*.js"
+      }
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-typescript": "^12.1.2",
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "rollup": "^4.29.1",
+    "tslib": "^2.8.1",
+    "typescript": "^5.7.2"
+  },
+  "keywords": [
+    "icons",
+    "react",
+    "svg",
+    "mingcute"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Richard9394/MingCute.git",
+    "directory": "packages/mingcute-react"
+  }
+}

--- a/packages/mingcute-react/rollup.config.mjs
+++ b/packages/mingcute-react/rollup.config.mjs
@@ -1,0 +1,46 @@
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+
+const external = ['react', 'react/jsx-runtime'];
+
+export default [
+  // ESM
+  {
+    input: 'src/index.ts',
+    output: {
+      dir: 'dist/esm',
+      format: 'esm',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+    },
+    external,
+    plugins: [
+      resolve(),
+      typescript({
+        outDir: 'dist/esm',
+        declaration: true,
+        declarationDir: 'dist/esm',
+      }),
+    ],
+  },
+  // CJS
+  {
+    input: 'src/index.ts',
+    output: {
+      dir: 'dist/cjs',
+      format: 'cjs',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      exports: 'named',
+    },
+    external,
+    plugins: [
+      resolve(),
+      typescript({
+        outDir: 'dist/cjs',
+        declaration: true,
+        declarationDir: 'dist/cjs',
+      }),
+    ],
+  },
+];

--- a/packages/mingcute-react/src/Icon.tsx
+++ b/packages/mingcute-react/src/Icon.tsx
@@ -1,0 +1,22 @@
+import { forwardRef } from 'react';
+import type { IconProps } from './types';
+
+export const Icon = forwardRef<SVGSVGElement, IconProps & { children: React.ReactNode }>(
+  ({ size = 24, color = 'currentColor', children, ...props }, ref) => {
+    return (
+      <svg
+        ref={ref}
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill={color}
+        {...props}
+      >
+        {children}
+      </svg>
+    );
+  }
+);
+
+Icon.displayName = 'Icon';

--- a/packages/mingcute-react/src/types.ts
+++ b/packages/mingcute-react/src/types.ts
@@ -1,0 +1,6 @@
+import type { SVGProps } from 'react';
+
+export interface IconProps extends SVGProps<SVGSVGElement> {
+  size?: number | string;
+  color?: string;
+}

--- a/packages/mingcute-react/tsconfig.json
+++ b/packages/mingcute-react/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/mingcute-vue/package.json
+++ b/packages/mingcute-vue/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@mingcute/vue",
+  "version": "0.1.0",
+  "description": "MingCute Icons for Vue",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "types": "./dist/esm/icons/*.d.ts",
+        "default": "./dist/esm/icons/*.js"
+      },
+      "require": {
+        "types": "./dist/cjs/icons/*.d.ts",
+        "default": "./dist/cjs/icons/*.js"
+      }
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-typescript": "^12.1.2",
+    "rollup": "^4.29.1",
+    "tslib": "^2.8.1",
+    "typescript": "^5.7.2",
+    "vue": "^3.5.13"
+  },
+  "keywords": [
+    "icons",
+    "vue",
+    "svg",
+    "mingcute"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Richard9394/MingCute.git",
+    "directory": "packages/mingcute-vue"
+  }
+}

--- a/packages/mingcute-vue/rollup.config.mjs
+++ b/packages/mingcute-vue/rollup.config.mjs
@@ -1,0 +1,46 @@
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+
+const external = ['vue'];
+
+export default [
+  // ESM
+  {
+    input: 'src/index.ts',
+    output: {
+      dir: 'dist/esm',
+      format: 'esm',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+    },
+    external,
+    plugins: [
+      resolve(),
+      typescript({
+        outDir: 'dist/esm',
+        declaration: true,
+        declarationDir: 'dist/esm',
+      }),
+    ],
+  },
+  // CJS
+  {
+    input: 'src/index.ts',
+    output: {
+      dir: 'dist/cjs',
+      format: 'cjs',
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      exports: 'named',
+    },
+    external,
+    plugins: [
+      resolve(),
+      typescript({
+        outDir: 'dist/cjs',
+        declaration: true,
+        declarationDir: 'dist/cjs',
+      }),
+    ],
+  },
+];

--- a/packages/mingcute-vue/src/Icon.ts
+++ b/packages/mingcute-vue/src/Icon.ts
@@ -1,0 +1,30 @@
+import { defineComponent, h, type PropType, type VNode } from 'vue';
+
+export const Icon = defineComponent({
+  name: 'Icon',
+  props: {
+    size: {
+      type: [Number, String] as PropType<number | string>,
+      default: 24,
+    },
+    color: {
+      type: String,
+      default: 'currentColor',
+    },
+  },
+  setup(props, { slots, attrs }) {
+    return () =>
+      h(
+        'svg',
+        {
+          xmlns: 'http://www.w3.org/2000/svg',
+          width: props.size,
+          height: props.size,
+          viewBox: '0 0 24 24',
+          fill: props.color,
+          ...attrs,
+        },
+        slots.default?.()
+      );
+  },
+});

--- a/packages/mingcute-vue/src/types.ts
+++ b/packages/mingcute-vue/src/types.ts
@@ -1,0 +1,6 @@
+import type { SVGAttributes } from 'vue';
+
+export interface IconProps extends /* @vue-ignore */ SVGAttributes {
+  size?: number | string;
+  color?: string;
+}

--- a/packages/mingcute-vue/tsconfig.json
+++ b/packages/mingcute-vue/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "jsx": "preserve"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -1,0 +1,253 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { glob } from 'glob';
+import { optimize } from 'svgo';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+const SVG_DIR = path.join(ROOT_DIR, 'svg');
+const REACT_ICONS_DIR = path.join(ROOT_DIR, 'packages/mingcute-react/src/icons');
+const VUE_ICONS_DIR = path.join(ROOT_DIR, 'packages/mingcute-vue/src/icons');
+
+// Convert snake_case to PascalCase
+function toPascalCase(str) {
+  return str
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+// Convert snake_case to kebab-case (lowercase)
+function toKebabCase(str) {
+  return str.replace(/_/g, '-').toLowerCase();
+}
+
+// Parse icon name to get base name and variant
+function parseIconName(iconName) {
+  if (iconName.endsWith('_fill')) {
+    return { baseName: iconName.slice(0, -5), variant: 'fill' };
+  }
+  if (iconName.endsWith('_line')) {
+    return { baseName: iconName.slice(0, -5), variant: 'line' };
+  }
+  return { baseName: iconName, variant: null };
+}
+
+// Parse SVG and extract inner content
+function parseSvg(svgContent) {
+  const result = optimize(svgContent, {
+    plugins: [
+      'preset-default',
+      'removeDimensions',
+      {
+        name: 'removeAttrs',
+        params: {
+          attrs: ['xmlns', 'width', 'height'],
+        },
+      },
+    ],
+  });
+
+  const optimized = result.data;
+  const match = optimized.match(/<svg[^>]*>([\s\S]*)<\/svg>/);
+  if (!match) return null;
+
+  let innerContent = match[1].trim();
+  innerContent = innerContent.replace(/fill="#[0-9a-fA-F]{6}"/g, '');
+  innerContent = innerContent.replace(/fill="none"/g, 'fill="none"');
+
+  return innerContent;
+}
+
+// Convert HTML attributes to JSX
+function toJsxContent(innerContent) {
+  return innerContent
+    .replace(/fill-rule=/g, 'fillRule=')
+    .replace(/clip-rule=/g, 'clipRule=')
+    .replace(/clip-path=/g, 'clipPath=')
+    .replace(/stroke-width=/g, 'strokeWidth=')
+    .replace(/stroke-linecap=/g, 'strokeLinecap=')
+    .replace(/stroke-linejoin=/g, 'strokeLinejoin=')
+    .replace(/stroke-miterlimit=/g, 'strokeMiterlimit=')
+    .replace(/stroke-dasharray=/g, 'strokeDasharray=')
+    .replace(/stroke-dashoffset=/g, 'strokeDashoffset=')
+    .replace(/stroke-opacity=/g, 'strokeOpacity=')
+    .replace(/fill-opacity=/g, 'fillOpacity=')
+    .replace(/stop-color=/g, 'stopColor=')
+    .replace(/stop-opacity=/g, 'stopOpacity=')
+    .replace(/xlink:href=/g, 'xlinkHref=')
+    .replace(/xml:space=/g, 'xmlSpace=');
+}
+
+// Generate React component file with both Fill and Line variants
+function generateReactFile(basePascalName, variants) {
+  const components = [];
+  const exports = [];
+
+  for (const [variant, innerContent] of Object.entries(variants)) {
+    const componentName = `${basePascalName}${variant === 'fill' ? 'Fill' : 'Line'}`;
+    const jsxContent = toJsxContent(innerContent);
+
+    components.push(`
+export const ${componentName} = forwardRef<SVGSVGElement, IconProps>((props, ref) => (
+  <Icon ref={ref} {...props}>
+    ${jsxContent}
+  </Icon>
+));
+
+${componentName}.displayName = '${componentName}';`);
+
+    exports.push(componentName);
+  }
+
+  return `import { forwardRef } from 'react';
+import { Icon } from '../Icon';
+import type { IconProps } from '../types';
+${components.join('\n')}
+`;
+}
+
+// Generate Vue component file with both Fill and Line variants
+function generateVueFile(basePascalName, variants) {
+  const components = [];
+
+  for (const [variant, innerContent] of Object.entries(variants)) {
+    const componentName = `${basePascalName}${variant === 'fill' ? 'Fill' : 'Line'}`;
+    const escapedContent = innerContent.replace(/`/g, '\\`');
+
+    components.push(`
+export const ${componentName} = defineComponent({
+  name: '${componentName}',
+  props: {
+    size: {
+      type: [Number, String] as PropType<number | string>,
+      default: 24,
+    },
+    color: {
+      type: String,
+      default: 'currentColor',
+    },
+  },
+  setup(props, { attrs }) {
+    return () =>
+      h(
+        Icon,
+        { size: props.size, color: props.color, ...attrs },
+        () => [
+          h('g', { innerHTML: \`${escapedContent}\` }),
+        ]
+      );
+  },
+});`);
+  }
+
+  return `import { defineComponent, h, type PropType } from 'vue';
+import { Icon } from '../Icon';
+${components.join('\n')}
+`;
+}
+
+// Generate index.ts exports
+function generateIndexExports(iconGroups, framework) {
+  const baseExports =
+    framework === 'react'
+      ? `export { Icon } from './Icon';
+export type { IconProps } from './types';
+
+`
+      : `export { Icon } from './Icon';
+export type { IconProps } from './types';
+
+`;
+
+  const iconExports = [];
+  for (const { basePascalName, kebabName, variants } of iconGroups) {
+    const componentNames = Object.keys(variants).map(
+      (v) => `${basePascalName}${v === 'fill' ? 'Fill' : 'Line'}`
+    );
+    iconExports.push(`export { ${componentNames.join(', ')} } from './icons/${kebabName}';`);
+  }
+
+  return baseExports + iconExports.join('\n') + '\n';
+}
+
+async function main() {
+  console.log('Generating icons...\n');
+
+  await fs.mkdir(REACT_ICONS_DIR, { recursive: true });
+  await fs.mkdir(VUE_ICONS_DIR, { recursive: true });
+
+  const svgFiles = await glob('**/*.svg', { cwd: SVG_DIR });
+  console.log(`Found ${svgFiles.length} SVG files\n`);
+
+  // Group icons by base name
+  const iconMap = new Map();
+
+  for (const svgFile of svgFiles) {
+    const svgPath = path.join(SVG_DIR, svgFile);
+    const iconName = path.basename(svgFile, '.svg');
+    const { baseName, variant } = parseIconName(iconName);
+
+    if (!variant) {
+      console.warn(`Skipping icon without variant: ${iconName}`);
+      continue;
+    }
+
+    try {
+      const svgContent = await fs.readFile(svgPath, 'utf-8');
+      const innerContent = parseSvg(svgContent);
+
+      if (!innerContent) {
+        console.error(`Failed to parse: ${svgFile}`);
+        continue;
+      }
+
+      if (!iconMap.has(baseName)) {
+        iconMap.set(baseName, {});
+      }
+      iconMap.get(baseName)[variant] = innerContent;
+    } catch (error) {
+      console.error(`Error processing ${svgFile}:`, error.message);
+    }
+  }
+
+  console.log(`Grouped into ${iconMap.size} icon sets\n`);
+
+  const iconGroups = [];
+  let fileCount = 0;
+
+  for (const [baseName, variants] of iconMap) {
+    const basePascalName = toPascalCase(baseName);
+    const kebabName = toKebabCase(baseName);
+
+    // Generate React file
+    const reactCode = generateReactFile(basePascalName, variants);
+    await fs.writeFile(path.join(REACT_ICONS_DIR, `${kebabName}.tsx`), reactCode);
+
+    // Generate Vue file
+    const vueCode = generateVueFile(basePascalName, variants);
+    await fs.writeFile(path.join(VUE_ICONS_DIR, `${kebabName}.ts`), vueCode);
+
+    iconGroups.push({ basePascalName, kebabName, variants });
+    fileCount++;
+  }
+
+  // Sort for consistent output
+  iconGroups.sort((a, b) => a.kebabName.localeCompare(b.kebabName));
+
+  // Generate index files
+  const reactIndex = generateIndexExports(iconGroups, 'react');
+  await fs.writeFile(path.join(ROOT_DIR, 'packages/mingcute-react/src/index.ts'), reactIndex);
+
+  const vueIndex = generateIndexExports(iconGroups, 'vue');
+  await fs.writeFile(path.join(ROOT_DIR, 'packages/mingcute-vue/src/index.ts'), vueIndex);
+
+  const totalComponents = iconGroups.reduce((acc, g) => acc + Object.keys(g.variants).length, 0);
+
+  console.log(`Generation complete!`);
+  console.log(`  Icon sets: ${fileCount}`);
+  console.log(`  Total components: ${totalComponents}`);
+}
+
+main().catch(console.error);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
- Set up pnpm workspace with packages for React and Vue
- Add code generation script for icon components
- Configure Rollup build with tree-shaking support
- Add base Icon component for both frameworks