### PR TITLE
Pin public packages to npmjs

### DIFF
--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -61,6 +61,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": true

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -69,6 +69,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -83,6 +83,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -80,6 +80,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -77,6 +77,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -83,6 +83,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/svg/package.json
+++ b/packages/svg/package.json
@@ -48,6 +48,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -73,6 +73,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -76,6 +76,7 @@
     "vue": "^3.5.0"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -73,6 +73,7 @@
     "typescript": "^5.7.2"
   },
   "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
   "sideEffects": false

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -45,7 +45,9 @@ export function validateRelease(policy, packages) {
     if (manifest.version !== policy.version) errors.push(`${manifest.name} must use version ${policy.version}`);
     if (manifest.license !== 'Apache-2.0') errors.push(`${manifest.name} must use Apache-2.0`);
     if (manifest.publishConfig?.access !== 'public') errors.push(`${manifest.name} must use public npm access`);
-    if (manifest.publishConfig?.registry) errors.push(`${manifest.name} must not override the public npm registry`);
+    if (manifest.publishConfig?.registry !== 'https://registry.npmjs.org/') {
+      errors.push(`${manifest.name} must publish explicitly to the public npm registry`);
+    }
     if (manifest.homepage !== WEBSITE) errors.push(`${manifest.name} homepage must be ${WEBSITE}`);
     if (manifest.repository?.url !== REPOSITORY) errors.push(`${manifest.name} must point to the public repository`);
     if (manifest.bugs?.url !== ISSUES) errors.push(`${manifest.name} issues must point to the public repository`);

--- a/scripts/release-policy.test.mjs
+++ b/scripts/release-policy.test.mjs
@@ -12,6 +12,9 @@ test('the free release contains exactly ten public Apache packages', async () =>
   const release = validateRelease(policy, packages);
   assert.equal(release.length, 10);
   assert.equal(new Set(release.map(({ version }) => version)).size, 1);
+  assert.equal(packages.every(({ manifest }) =>
+    manifest.publishConfig?.registry === 'https://registry.npmjs.org/' &&
+    manifest.publishConfig?.access === 'public'), true);
 });
 
 test('internal build packages cannot be published', async () => {


### PR DESCRIPTION
## Summary
- pin all public package manifests to the npmjs registry
- enforce the registry destination in release policy checks
- prevent local Pro registry configuration from redirecting public releases

## Validation
- pnpm check
- pnpm pack:dry
- pnpm audit --prod --audit-level high