### PR TITLE
release: Mingcute Icons v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published framework package manifests with installable icon dependencies instead of workspace-only ranges.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mingcute-icons",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "description": "Public workspace for building and maintaining free MingCute icon packages.",
   "keywords": [

--- a/packages/font/CHANGELOG.md
+++ b/packages/font/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/font",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute WOFF2 icon fonts, CSS mappings, and codepoint metadata.",
   "keywords": [
     "icons",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/icons",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Framework-neutral Mingcute icon definitions for Core Regular and Filled.",
   "keywords": [
     "icons",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/react-native",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute icon components for React Native.",
   "keywords": [
     "icons",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute SVG icon components for React.",
   "keywords": [
     "icons",

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/solid",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute SVG icon components for SolidJS.",
   "keywords": [
     "icons",

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/svelte",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute SVG icon components for Svelte.",
   "keywords": [
     "icons",

--- a/packages/svg/CHANGELOG.md
+++ b/packages/svg/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/svg/package.json
+++ b/packages/svg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/svg",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Optimized Carefully crafted Mingcute SVG icons for Core Regular and Filled.",
   "keywords": [
     "icons",

--- a/packages/vanilla/CHANGELOG.md
+++ b/packages/vanilla/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/vanilla",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute SVG strings and DOM helpers for vanilla JavaScript.",
   "keywords": [
     "icons",

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/vue",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute SVG icon components for Vue.",
   "keywords": [
     "icons",

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.0.2] - 2026-07-31
+
+### Fixed
+
+- Published metadata now resolves cleanly outside the workspace.
+
 ## [3.0.1] - 2026-07-30
 
 ### Documentation

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mingcute/web-components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mingcute SVG icon custom elements.",
   "keywords": [
     "icons",

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "version": "3.0.1",
+  "version": "3.0.2",
   "requiredPackages": [
     "@mingcute/icons",
     "@mingcute/svg",


### PR DESCRIPTION
Fix published package manifests so framework packages install outside the pnpm workspace. The release uses pnpm publish metadata transformation to replace workspace ranges with the coordinated 3.0.2 version.